### PR TITLE
Corrigido problemas com usuários excluidos

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,11 @@ class ApplicationController < ActionController::Base
   def set_current_user
     if session[:user_id]
       Current.user = User.find_by(id: session[:user_id])
+      # se o usuario nao existir mais desloga ele e manda pra tela principal
+      if !Current.user
+        session[:user_id] = nil
+        redirect_to root_path
+      end
     end
   end
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,5 +1,7 @@
 class UserController < ApplicationController
     before_action :set_user, only: %i[ update destroy updateFromDash ]
+    before_action :dont_delete_itself, only: %i[ destroy ]
+
 
     def update
       if Current.user.situacao=="Visitante"
@@ -39,6 +41,10 @@ class UserController < ApplicationController
     
     # DELETE /posts/1 or /posts/1.json
     def destroy
+      comentarios = Comentario.where("user_id = "+(@user.id).to_s)
+      comentarios.each do |comentario|
+        comentario.destroy
+      end
       @user.destroy
       respond_to do |format|
         format.html { redirect_to dashboard_users_path, success: 'Usuário deletado com sucesso!' }
@@ -49,9 +55,19 @@ class UserController < ApplicationController
     private
       # Use callbacks to share common setup or constraints between actions.
       def set_user
-        @user = User.find(params[:id])
-        if User.find(session[:user_id]).situacao != "Bolsista" && Current.user.id!=@user.id
-            redirect_to request.referer, error: "Voce não pode editar esse usuário!"
+        @user = User.find(params[:id]) rescue nil
+        if @user
+          if User.find(session[:user_id]).situacao != "Bolsista" && Current.user.id!=@user.id
+              redirect_to request.referer, error: "Você não pode editar esse usuário!"
+          end
+        else
+          redirect_to request.referer, error: "Erro. Usuário inválido"
+        end
+      end
+
+      def dont_delete_itself
+        if Current.user.id==@user.id
+          redirect_to request.referer, error: "Você não pode excluir seu próprio perfil!"
         end
       end
   


### PR DESCRIPTION
Usuário não pode mais se excluir
Exclui todos comentários antes de excluir um usuário
Adicionado lógica para deslogar um usuário quando ele for excluido assim que ele tentar fazer algo que precisa de autorização
Closes #81 and closes #91